### PR TITLE
VesselInformation Efficalculation changes

### DIFF
--- a/Source/DecayManager.cs
+++ b/Source/DecayManager.cs
@@ -163,14 +163,14 @@ namespace WhitecatIndustries
         {
             VesselData.ClearVesselData(vessel);
         }
-
+/* unused in 1.5.0
         public void UpdateVesselDataResources(Vessel vessel)
         {
             //151 VesselData.UpdateVesselFuel(vessel, ResourceManager.GetResources(vessel, Settings.ReadStationKeepingResource()));
-            VesselData.UpdateVesselFuel(vessel, ResourceManager.GetResources2(vessel));//151
+            VesselData.UpdateVesselFuel(vessel, ResourceManager.GetResources(vessel));//151
             VesselData.UpdateVesselResource(vessel, ResourceManager.GetResourceNames(vessel));//151
         }
-
+*/
         #endregion
 
         #region Check Subroutines 
@@ -361,7 +361,7 @@ namespace WhitecatIndustries
                                     {
                                         StationKeepingManager.FuelManager(vessel);
                                     }
-
+/* not necessary in 1.5.0
                                     if (HighLogic.LoadedSceneIsFlight) // UI Resource Updating 1.4.2
                                     {
                                         if (vessel == FlightGlobals.ActiveVessel)
@@ -369,6 +369,7 @@ namespace WhitecatIndustries
                                             UpdateVesselDataResources(vessel);
                                         }
                                     }
+                                    */
                                 }
                             }
                         }

--- a/Source/ModuleOrbitalDecay.cs
+++ b/Source/ModuleOrbitalDecay.cs
@@ -441,16 +441,17 @@ namespace WhitecatIndustries
 
         public void Save(ConfigNode node)
         {
-            string temporary = "";
-            for (int i = 0; i < resources.Count(); i++)
+            string temporary;
+            temporary = resources[0];
+            for (int i = 1; i < resources.Count(); i++)
             {
-                temporary += resources[i] + ' ';
+                temporary += ' ' + resources[i];
             }
             node.AddValue("resources", temporary);
-            temporary = "";
-            for (int i = 0; i < amounts.Count(); i++)
+            temporary = amounts[0].ToString();
+            for (int i = 1; i < amounts.Count(); i++)
             {
-                temporary += amounts[i].ToString() + ' ';
+                temporary += ' ' + amounts[i].ToString();
             }
             node.AddValue("amounts", temporary);
             temporary = "";
@@ -469,7 +470,7 @@ namespace WhitecatIndustries
             node.AddValue("IsStationKeeping", IsStationKeeping);
         }
 
-       
+
     }
 
 

--- a/Source/ResourceManager.cs
+++ b/Source/ResourceManager.cs
@@ -70,7 +70,7 @@ namespace WhitecatIndustries
                 }
             }
         }
-
+/* unused in 1.50
         public static void CatchUp(Vessel vessel, string resource)
         {
             int MonoPropId = PartResourceLibrary.Instance.GetDefinition(resource).id;
@@ -81,7 +81,7 @@ namespace WhitecatIndustries
 
             }
         }
-
+*/
         public static string GetResourceNames(Vessel vessel)//151 
         {
             string ResourceNames = "";
@@ -148,7 +148,7 @@ namespace WhitecatIndustries
             return ResourceRatio;
         }
 
-        public static double GetResources2(Vessel vessel)//returns sum of used resources
+        public static double GetResources(Vessel vessel)//returns sum of used resources
         {
             double fuel = 0;
             if (vessel == FlightGlobals.ActiveVessel)
@@ -189,8 +189,8 @@ namespace WhitecatIndustries
             return fuel;
         }
 
-
-        public static double GetResources(Vessel vessel, string resource)
+/* old code, replaced in  1.5.0
+        public static double GetResources5(Vessel vessel, string resource)
         {
             double quantity = 0.0;
 
@@ -231,7 +231,7 @@ namespace WhitecatIndustries
             return quantity;
         }
 
-        
+   */     
 
 
 
@@ -240,16 +240,6 @@ namespace WhitecatIndustries
         public static float GetEfficiency(string resource) // Eventually combine with engine ISP but quite nice like this!
         {
             float Efficiency = 0.0f;
-           //151
-           /*PartResourceDefinition resourceDef = PartResourceLibrary.Instance.GetDefinition(resource);
-            if (Settings.ReadRD())
-            {
-                Efficiency = resourceDef.density * 0.9f; // Balance here!
-            }
-            else
-            {
-                Efficiency = resourceDef.density * 10.0f;
-            }*/
             foreach (string res in resource.Split(' '))
             {
                 PartResourceDefinition resourceDef = PartResourceLibrary.Instance.GetDefinition(res);

--- a/Source/ResourceManager.cs
+++ b/Source/ResourceManager.cs
@@ -62,7 +62,6 @@ namespace WhitecatIndustries
                         if (protopartmodulesnapshot.moduleName == "ModuleOrbitalDecay")
                         {
                             ConfigNode node = protopartmodulesnapshot.moduleValues.GetNode("stationKeepData");
-                          //  quantity += double.Parse(node.GetValue("fuelLost"));
                             node.SetValue("fuelLost", (quantity + double.Parse(node.GetValue("fuelLost"))).ToString());
                             break;
                         }
@@ -167,7 +166,6 @@ namespace WhitecatIndustries
             else
             {
                 ProtoVessel proto = vessel.protoVessel;
-
                 foreach (ProtoPartSnapshot protopart in proto.protoPartSnapshots)
                 {
                     foreach (ProtoPartModuleSnapshot protopartmodulesnapshot in protopart.modules)

--- a/Source/ResourceManager.cs
+++ b/Source/ResourceManager.cs
@@ -236,7 +236,7 @@ namespace WhitecatIndustries
 
 
 
-
+/*  not used in 1.5.0
         public static float GetEfficiency(string resource) // Eventually combine with engine ISP but quite nice like this!
         {
             float Efficiency = 0.0f;
@@ -254,5 +254,6 @@ namespace WhitecatIndustries
             }
             return (Efficiency / resource.Split(' ').Count());
         }
+        */
     }
 }

--- a/Source/ResourceManager.cs
+++ b/Source/ResourceManager.cs
@@ -190,7 +190,7 @@ namespace WhitecatIndustries
         }
 
 /* old code, replaced in  1.5.0
-        public static double GetResources5(Vessel vessel, string resource)
+        public static double GetResources(Vessel vessel, string resource)
         {
             double quantity = 0.0;
 

--- a/Source/StationKeepingManager.cs
+++ b/Source/StationKeepingManager.cs
@@ -94,10 +94,12 @@ namespace WhitecatIndustries
         public static void FuelManager(Vessel vessel)
         {
             string ResourceName = "";
-            ResourceName = VesselData.FetchResource(vessel);
+            //ResourceName = VesselData.FetchResource(vessel);
+            ResourceName = ResourceManager.GetResourceNames(vessel);
             double CurrentFuel = 0;
-            CurrentFuel = VesselData.FetchFuel(vessel);
-            double ResourceEfficiency = ResourceManager.GetEfficiency(ResourceName);//151 TODO change effi calculation based on vessel engine ISP stored in stationKeepData.ISP
+        //    CurrentFuel = VesselData.FetchFuel(vessel);
+            CurrentFuel = ResourceManager.GetResources(vessel);
+            double ResourceEfficiency = VesselData.FetchEfficiency(vessel);//ResourceManager.GetEfficiency(ResourceName); effi calculation based on vessel engine ISP stored in stationKeepData.ISP
             double LostFuel = 0.0;
 
             LostFuel = Math.Abs((DecayManager.DecayRateAtmosphericDrag(vessel) + DecayManager.DecayRateRadiationPressure(vessel) + DecayManager.DecayRateYarkovskyEffect(vessel))) * Settings.ReadResourceRateDifficulty() * ResourceEfficiency; // * Fuel Multiplier

--- a/Source/StationKeepingManager.cs
+++ b/Source/StationKeepingManager.cs
@@ -99,7 +99,8 @@ namespace WhitecatIndustries
             double CurrentFuel = 0;
         //    CurrentFuel = VesselData.FetchFuel(vessel);
             CurrentFuel = ResourceManager.GetResources(vessel);
-            double ResourceEfficiency = VesselData.FetchEfficiency(vessel);//ResourceManager.GetEfficiency(ResourceName); effi calculation based on vessel engine ISP stored in stationKeepData.ISP
+     //       double ResourceEfficiency = ResourceManager.GetEfficiency(ResourceName);
+            double ResourceEfficiency = VesselData.FetchEfficiency(vessel);// effi calculation based on vessel engine ISP stored in stationKeepData.ISP NEED ballance
             double LostFuel = 0.0;
 
             LostFuel = Math.Abs((DecayManager.DecayRateAtmosphericDrag(vessel) + DecayManager.DecayRateRadiationPressure(vessel) + DecayManager.DecayRateYarkovskyEffect(vessel))) * Settings.ReadResourceRateDifficulty() * ResourceEfficiency; // * Fuel Multiplier

--- a/Source/UserInterface.cs
+++ b/Source/UserInterface.cs
@@ -179,9 +179,10 @@ namespace WhitecatIndustries
                 if (vessel.situation == Vessel.Situations.ORBITING && vessel.vesselType != VesselType.SpaceObject && vessel.vesselType != VesselType.Unknown && vessel.vesselType != VesselType.Debris)
                 {
                     var StationKeeping = VesselData.FetchStationKeeping(vessel).ToString();
-                    var StationKeepingFuelRemaining = VesselData.FetchFuel(vessel).ToString("F3");
-                    // var StationKeepingFuelResource = VesselData.FetchResource(vessel);
-                    var Resource = VesselData.FetchResource(vessel);
+                 //   var StationKeepingFuelRemaining = VesselData.FetchFuel(vessel).ToString("F3");
+                    var StationKeepingFuelRemaining = ResourceManager.GetResources(vessel).ToString("F3");
+                //    var Resource = VesselData.FetchResource(vessel);//151
+                    var Resource = ResourceManager.GetResourceNames(vessel);
                     var ButtonText = "";
                     var HoursInDay = 6.0;
 
@@ -274,8 +275,8 @@ namespace WhitecatIndustries
                     GUILayout.Space(2);
                     GUILayout.Label("Station Keeping Fuel Remaining: " + StationKeepingFuelRemaining);
                     GUILayout.Space(2);
-                    GUILayout.Label("Station Keeping Fuel Type: " + Resource);
-                    GUILayout.Space(2); 
+                    GUILayout.Label("Using Fuel Type: " + Resource);//151
+                    GUILayout.Space(2); //151
 
                     if (StationKeeping == "True")
                     {
@@ -284,7 +285,7 @@ namespace WhitecatIndustries
                         DecayRateSKL = DecayManager.DecayRateAtmosphericDrag(vessel) + DecayManager.DecayRateRadiationPressure(vessel) + DecayManager.DecayRateYarkovskyEffect(vessel);
 
 
-                        double StationKeepingLifetime = (double.Parse(StationKeepingFuelRemaining) / ((DecayRateSKL / TimeWarp.CurrentRate) * ResourceManager.GetEfficiency(Resource) * Settings.ReadResourceRateDifficulty())) / (60 * 60 * HoursInDay);
+                        double StationKeepingLifetime = (double.Parse(StationKeepingFuelRemaining) / ((DecayRateSKL / TimeWarp.CurrentRate) * VesselData.FetchEfficiency(vessel) /*ResourceManager.GetEfficiency(Resource)*/ * Settings.ReadResourceRateDifficulty())) / (60 * 60 * HoursInDay);
 
                         if (StationKeepingLifetime < -5) // SRP Fixes
                         {

--- a/Source/VesselData.cs
+++ b/Source/VesselData.cs
@@ -775,6 +775,12 @@ namespace WhitecatIndustries
         }
 
 
+        /* simple ISP dependant effi calculation.
+         * NEEDS ballancing
+         * removing fuel based on dV would make more sense,
+         * and more thinkering to firgure it out
+         * 1.60 milestone maybe?
+         */
         public static float FetchEfficiency(Vessel vessel)
         {
             float Efficiency = 0;

--- a/Source/VesselData.cs
+++ b/Source/VesselData.cs
@@ -136,8 +136,8 @@ namespace WhitecatIndustries
                 {
                     print("WhitecatIndustries - Orbital Decay - Vessel Information saved. Ondestroy");
                     File.ClearNodes();
-                   // VesselInformation.Save(FilePath);
-                    //VesselInformation.ClearNodes();
+                    VesselInformation.Save(FilePath);
+                   // VesselInformation.ClearNodes();
                 }
             }
         }
@@ -150,7 +150,7 @@ namespace WhitecatIndustries
                 {
                     print("WhitecatIndustries - Orbital Decay - Vessel Information saved.");
                     File.ClearNodes();
-                    //VesselInformation.Save(FilePath);
+                    VesselInformation.Save(FilePath);
                     //VesselInformation.ClearNodes();
                 }
             }
@@ -227,18 +227,17 @@ namespace WhitecatIndustries
 
             if (found == true)
             {
-                string ResourceName = "";
-                ResourceName = Settings.ReadStationKeepingResource();
-
+               // string ResourceName = "";
+               // ResourceName = Settings.ReadStationKeepingResource();
 
                 VesselNode.SetValue("Mass", (vessel.GetTotalMass() * 1000).ToString());
                 VesselNode.SetValue("Area", (CalculateVesselArea(vessel)).ToString());
                 //151VesselNode.SetValue("Fuel", (ResourceManager.GetResources(vessel, ResourceName)).ToString());
-                VesselNode.SetValue("Fuel", (ResourceManager.GetResources2(vessel)).ToString());//151
-                VesselNode.SetValue("Resource", ResourceManager.GetResourceNames(vessel));//151
+            //    VesselNode.SetValue("Fuel", (ResourceManager.GetResources(vessel)).ToString());//151
+             //   VesselNode.SetValue("Resource", ResourceManager.GetResourceNames(vessel));//151
             }
         }
-
+/* not used in 1.5.0
         public static string FetchResource(Vessel vessel)
         {
             string Resource = "";
@@ -260,6 +259,7 @@ namespace WhitecatIndustries
             }
             return Resource;
         }
+        */
 
         public static void ClearVesselData(Vessel vessel)
         {
@@ -286,8 +286,8 @@ namespace WhitecatIndustries
         {
             ConfigNode newVessel = new ConfigNode("VESSEL");
 
-            string ResourceName = "";
-            ResourceName = Settings.ReadStationKeepingResource();
+           // string ResourceName = "";
+           // ResourceName = Settings.ReadStationKeepingResource();
 
             newVessel.AddValue("name", vessel.GetName());
             newVessel.AddValue("id", vessel.id.ToString());
@@ -314,10 +314,10 @@ namespace WhitecatIndustries
             newVessel.AddValue("MNA", vessel.GetOrbitDriver().orbit.meanAnomalyAtEpoch);
             newVessel.AddValue("EPH", vessel.GetOrbitDriver().orbit.epoch);
 
-            newVessel.AddValue("StationKeeping", false.ToString());
+           // newVessel.AddValue("StationKeeping", false.ToString());
             //151newVessel.AddValue("Fuel", ResourceManager.GetResources(vessel, ResourceName));
-            newVessel.AddValue("Fuel", ResourceManager.GetResources2(vessel));//151
-            newVessel.AddValue("Resource", ResourceManager.GetResourceNames(vessel));//151
+        //    newVessel.AddValue("Fuel", ResourceManager.GetResources(vessel));//151
+        //    newVessel.AddValue("Resource", ResourceManager.GetResourceNames(vessel));//151
 
             return newVessel;
         }
@@ -774,9 +774,47 @@ namespace WhitecatIndustries
             return EPH;
         }
 
+
+        public static float FetchEfficiency(Vessel vessel)
+        {
+            float Efficiency = 0;
+            if (vessel == FlightGlobals.ActiveVessel)
+            {
+                List<ModuleOrbitalDecay> modlist  = vessel.FindPartModulesImplementing<ModuleOrbitalDecay>();
+                Efficiency = modlist.ElementAt(0).stationKeepData.ISP;
+               
+            }
+            else
+            {
+                ProtoVessel proto = vessel.protoVessel;
+
+                foreach (ProtoPartSnapshot protopart in proto.protoPartSnapshots)
+                {
+                    foreach (ProtoPartModuleSnapshot protopartmodulesnapshot in protopart.modules)
+                    {
+                        if (protopartmodulesnapshot.moduleName == "ModuleOrbitalDecay")
+                        {
+                            ConfigNode node = protopartmodulesnapshot.moduleValues.GetNode("stationKeepData");
+                            Efficiency = float.Parse(node.GetValue("ISP"));
+                            break;
+                        }
+                    }
+                }
+            }
+            if (Settings.ReadRD())
+            {
+                Efficiency *= 0.5f; // Balance here!
+            }
+            
+
+            return 1/Efficiency;
+        }
+
+/* unused in 1.5.0
         public static double FetchFuel(Vessel vessel)
         {
-            ConfigNode Data = VesselInformation;
+                                                                           
+           ConfigNode Data = VesselInformation;
             bool Vesselfound = false;
             double Fuel = 0.0;
 
@@ -794,8 +832,10 @@ namespace WhitecatIndustries
                     break;
                 }
             }
+
             return Fuel;
         }
+        */
 
         public static void UpdateBody(Vessel vessel, CelestialBody body)
         {
@@ -838,7 +878,7 @@ namespace WhitecatIndustries
                 }
             }
         }
-
+/* unused in 1.5.0
         public static void UpdateVesselResource(Vessel vessel, string Resource)
         {
             ConfigNode Data = VesselInformation;
@@ -859,6 +899,7 @@ namespace WhitecatIndustries
                 }
             }
         }
+        */
 
         public static double CalculateVesselArea(Vessel vessel)
         {


### PR DESCRIPTION
VesselInformation is not used for storage of any fuel related info
saving of VesselInformation restored
redundant values removed (commented out)

All non called methods are commented out with comment  "not used in 1.5.0"

Efficiency is now 1/ISP and 1/(ISP*0.5) for two difficulty settings - can be wrong way round
